### PR TITLE
Handle invalid edges in freeport/backend

### DIFF
--- a/freeport/backend/src/api_access/filter_edges.js
+++ b/freeport/backend/src/api_access/filter_edges.js
@@ -1,0 +1,13 @@
+// Assumes both `edges` and `nodes` are arrays.
+// Their interfaces can be found in 'insert.js'.
+function filterEdges(edges, nodes) {
+    const nodeSet = new Set(nodes.map((node) => node.name));
+
+    const bothNodesExist = (({from_node, to_node}) => {
+        return nodeSet.has(from_node) && nodeSet.has(to_node);
+    });
+
+    return edges.filter(bothNodesExist);
+}
+
+module.exports.default = filterEdges;

--- a/freeport/backend/src/api_access/filter_edges.js
+++ b/freeport/backend/src/api_access/filter_edges.js
@@ -2,12 +2,25 @@
 // Their interfaces can be found in 'insert.js'.
 function filterEdges(edges, nodes) {
     const nodeSet = new Set(nodes.map((node) => node.name));
+    const invalidEdges = [];
 
     const bothNodesExist = (({from_node, to_node}) => {
         return nodeSet.has(from_node) && nodeSet.has(to_node);
     });
 
-    return edges.filter(bothNodesExist);
+    edges = edges.filter((edge) => {
+        if (bothNodesExist(edge)) {
+            return true;
+        } else {
+            invalidEdges.push(edge);
+            return false;
+        }
+    });
+
+    return {
+        valid: edges,
+        invalid: invalidEdges,
+    };
 }
 
 module.exports.default = filterEdges;

--- a/freeport/backend/src/api_access/main.js
+++ b/freeport/backend/src/api_access/main.js
@@ -45,7 +45,10 @@ const insertDataIntoDatabase = async (
             );
         }
     };
-    edges = filterEdges(edges, nodes);
+    const filterResult = filterEdges(edges, nodes);
+    edges = filterResult.valid;
+    const invalidEdges = filterResult.invalid;
+    shouldLog && console.log(`${invalidEdges.length} invalid edges filtered out:\n`, invalidEdges);
     shouldLog && console.log(`Collected ${nodes.length} nodes and ${edges.length} edges.`);
 
     const errors = [];

--- a/freeport/backend/src/api_access/main.js
+++ b/freeport/backend/src/api_access/main.js
@@ -1,6 +1,7 @@
 const { writeToEndOfFile } = require("../scrape/file_io");
 const { promisedExecInFolder } = require("../scrape/util");
 const { AsyncBatch } = require("./batch");
+const filterEdges = require("./filter_edges").default;
 const { insertCrateNodesBatch, insertDependsEdgesBatch, createNode, createEdge } = require("./insert");
 
 const now = () => (new Date()).getTime();
@@ -18,7 +19,7 @@ const insertDataIntoDatabase = async (
     const numData = data.length;
 
     const nodes = [];
-    const edges = [];
+    let edges = [];
 
     for (let i = 0; i < numData; ++i) {
         const datum = data[i];
@@ -44,6 +45,7 @@ const insertDataIntoDatabase = async (
             );
         }
     };
+    edges = filterEdges(edges, nodes);
     shouldLog && console.log(`Collected ${nodes.length} nodes and ${edges.length} edges.`);
 
     const errors = [];

--- a/freeport/backend/src/api_access/main.js
+++ b/freeport/backend/src/api_access/main.js
@@ -51,16 +51,22 @@ const insertDataIntoDatabase = async (
     shouldLog && console.log(`${invalidEdges.length} invalid edges filtered out:\n`, invalidEdges);
     shouldLog && console.log(`Collected ${nodes.length} nodes and ${edges.length} edges.`);
 
+    if (nodes.length === 0) {
+        return { nodes, edges, errors: [] };
+    }
+
     const errors = [];
     const errorHandler = (e) => {
         errors.push(e);
         console.error(e.response.data);
     };
     const nodesBatch = new AsyncBatch(batchReleaseThreshold, insertCrateNodesBatch, shouldLog, errorHandler);
-    const edgesBatch = new AsyncBatch(batchReleaseThreshold, insertDependsEdgesBatch, shouldLog, errorHandler);
-
     await nodesBatch.consumeArray(nodes, "nodes");
-    await edgesBatch.consumeArray(edges, "edges");
+    
+    if (edges.length !== 0) {
+        const edgesBatch = new AsyncBatch(batchReleaseThreshold, insertDependsEdgesBatch, shouldLog, errorHandler);
+        await edgesBatch.consumeArray(edges, "edges");
+    }
 
     shouldLog && console.log(
         `Inserted ${nodes.length + edges.length} items into database in ${Math.round((now() - startTime) / 1000)}s with ${errors.length} errors caught.`

--- a/starfish/Rocket.toml
+++ b/starfish/Rocket.toml
@@ -1,5 +1,7 @@
 [default.databases.starfish]
 url = "mysql://root:root@localhost/starfish"
+# url = "postgres://root:root@localhost/starfish"
+# url = "sqlite:./starfish.db?mode=rwc"
 
 [default]
 address = "0.0.0.0"

--- a/starfish/starfish-core/Cargo.toml
+++ b/starfish/starfish-core/Cargo.toml
@@ -23,14 +23,14 @@ name = "starfish_core"
 path = "src/lib.rs"
 
 [dependencies]
-sea-orm = { version = "^0.6.0", default-features = false, features = [
+sea-orm = { git = "https://github.com/shpun817/sea-orm", default-features = false, features = [
     "macros",
     "sqlx-mysql",
     "runtime-async-std-native-tls",
     "debug-print",
 ]}
-sea-schema = { version = "^0.5.0", default-features = false, features = [ "migration", "debug-print" ] }
-sea-query = { version = "^0.21.0", features = ["thread-safe"] }
+sea-schema = { git = "https://github.com/shpun817/sea-schema", default-features = false, features = [ "migration", "debug-print" ] }
+sea-query = { version = "^0.24.0", features = ["thread-safe"] }
 futures-executor = { version = "^0.3" }
 async-trait = { version = "^0.1" }
 serde = { version = "^1" }

--- a/starfish/starfish-core/src/mutate/edge.rs
+++ b/starfish/starfish-core/src/mutate/edge.rs
@@ -391,6 +391,10 @@ impl Mutate {
             map_id_to_ancestors.insert(root_node.name, ancestors);
         }
 
+        if map_id_to_ancestors.is_empty() {
+            return Ok(());
+        }
+
         // map_id_to_ancestors is ready; the sizes of the sets in its values are the compound in_conn
         let cols = [
             NodeIden::Name.into_iden(),

--- a/starfish/starfish-core/src/mutate/edge.rs
+++ b/starfish/starfish-core/src/mutate/edge.rs
@@ -6,7 +6,7 @@ use crate::{
     lang::{
         iden::{EdgeIden, NodeIden},
         mutate::{MutateEdgeContentJson, MutateEdgeSelectorJson},
-        ClearEdgeJson, Edge, EdgeJson, EdgeJsonBatch, iden::{EdgeIden, NodeIden},
+        ClearEdgeJson, Edge, EdgeJson, EdgeJsonBatch,
     },
     schema::{format_edge_table_name, format_node_table_name},
 };
@@ -244,8 +244,7 @@ impl Mutate {
             .from(Alias::new(edge_table))
             .expr(Expr::cust("COUNT(*)"))
             .and_where(
-                Expr::col(EdgeIden::FromNode)
-                    .equals(Alias::new(node_table), NodeIden::Name),
+                Expr::col(EdgeIden::FromNode).equals(Alias::new(node_table), NodeIden::Name),
             );
         let mut stmt = Query::update();
         stmt.table(Alias::new(node_table)).value_expr(
@@ -260,9 +259,7 @@ impl Mutate {
         select
             .from(Alias::new(edge_table))
             .expr(Expr::cust("COUNT(*)"))
-            .and_where(
-                Expr::col(EdgeIden::ToNode).equals(Alias::new(node_table), NodeIden::Name),
-            );
+            .and_where(Expr::col(EdgeIden::ToNode).equals(Alias::new(node_table), NodeIden::Name));
         let mut stmt = Query::update();
         stmt.table(Alias::new(node_table)).value_expr(
             Alias::new(&format!("{}_in_conn", relation_name)),

--- a/starfish/starfish-core/src/mutate/edge.rs
+++ b/starfish/starfish-core/src/mutate/edge.rs
@@ -76,9 +76,11 @@ impl Mutate {
         db: &DbConn,
         edge_json_batch: EdgeJsonBatch,
     ) -> Result<(), DbErr> {
+        let cols = [EdgeIden::FromNode, EdgeIden::ToNode];
         let mut stmt = Query::insert();
         stmt.into_table(Alias::new(&format_edge_table_name(edge_json_batch.of)))
-            .columns([EdgeIden::FromNode, EdgeIden::ToNode]);
+            .columns(cols)
+            .on_conflict(OnConflict::columns(cols).update_columns(cols).to_owned());
 
         for edge_json in edge_json_batch.edges.into_iter() {
             stmt.values_panic([edge_json.from_node.into(), edge_json.to_node.into()]);

--- a/starfish/starfish-core/src/mutate/edge.rs
+++ b/starfish/starfish-core/src/mutate/edge.rs
@@ -83,9 +83,7 @@ impl Mutate {
         }
 
         let builder = db.get_database_backend();
-        let mut stmt = builder.build(&stmt);
-        stmt.sql = stmt.sql.replace("INSERT", "INSERT IGNORE");
-        db.execute(stmt).await?;
+        db.execute(builder.build(&stmt)).await?;
 
         Ok(())
     }

--- a/starfish/starfish-core/src/mutate/edge.rs
+++ b/starfish/starfish-core/src/mutate/edge.rs
@@ -11,7 +11,9 @@ use crate::{
     schema::{format_edge_table_name, format_node_table_name},
 };
 use sea_orm::{ConnectionTrait, DbConn, DbErr, EntityTrait, FromQueryResult, Value};
-use sea_query::{Alias, Cond, Expr, IntoIden, Query, QueryStatementBuilder, SimpleExpr, OnConflict};
+use sea_query::{
+    Alias, Cond, Expr, IntoIden, OnConflict, Query, QueryStatementBuilder, SimpleExpr,
+};
 
 #[derive(Debug, Clone, FromQueryResult)]
 struct Node {

--- a/starfish/starfish-core/src/mutate/edge.rs
+++ b/starfish/starfish-core/src/mutate/edge.rs
@@ -6,7 +6,7 @@ use crate::{
     lang::{
         iden::{EdgeIden, NodeIden},
         mutate::{MutateEdgeContentJson, MutateEdgeSelectorJson},
-        ClearEdgeJson, Edge, EdgeJson, EdgeJsonBatch,
+        ClearEdgeJson, Edge, EdgeJson, EdgeJsonBatch, iden::{EdgeIden, NodeIden},
     },
     schema::{format_edge_table_name, format_node_table_name},
 };
@@ -244,7 +244,8 @@ impl Mutate {
             .from(Alias::new(edge_table))
             .expr(Expr::cust("COUNT(*)"))
             .and_where(
-                Expr::col(EdgeIden::FromNode).equals(Alias::new(node_table), NodeIden::Name),
+                Expr::col(EdgeIden::FromNode)
+                    .equals(Alias::new(node_table), NodeIden::Name),
             );
         let mut stmt = Query::update();
         stmt.table(Alias::new(node_table)).value_expr(
@@ -259,7 +260,9 @@ impl Mutate {
         select
             .from(Alias::new(edge_table))
             .expr(Expr::cust("COUNT(*)"))
-            .and_where(Expr::col(EdgeIden::ToNode).equals(Alias::new(node_table), NodeIden::Name));
+            .and_where(
+                Expr::col(EdgeIden::ToNode).equals(Alias::new(node_table), NodeIden::Name),
+            );
         let mut stmt = Query::update();
         stmt.table(Alias::new(node_table)).value_expr(
             Alias::new(&format!("{}_in_conn", relation_name)),

--- a/starfish/starfish-core/src/mutate/node.rs
+++ b/starfish/starfish-core/src/mutate/node.rs
@@ -14,8 +14,8 @@ use crate::{
     schema::{format_node_attribute_name, format_node_table_name},
 };
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DbConn, DbErr, DeriveIden, EntityTrait, FromQueryResult,
-    JoinType, JsonValue, QueryFilter, Value,
+    ColumnTrait, ConnectionTrait, DbConn, DbErr, EntityTrait, FromQueryResult, JoinType, JsonValue,
+    QueryFilter, Value,
 };
 use sea_query::{Alias, Cond, Expr, IntoIden, Query};
 

--- a/starfish/starfish-core/src/query/mod.rs
+++ b/starfish/starfish-core/src/query/mod.rs
@@ -400,7 +400,7 @@ impl Query {
             let stmt = sea_query::Query::select()
                 .column(NodeQueryIden::Name)
                 .expr_as(Expr::col(Alias::new(&weight_key)), NodeQueryIden::Weight)
-                .expr_as(Expr::val(Some(0_u64)), NodeQueryIden::Depth)
+                .expr_as(Expr::val(Option::<u64>::None), NodeQueryIden::Depth)
                 .from(Alias::new(node_table))
                 .and_where(Expr::col(NodeQueryIden::Name).is_in(result_nodes))
                 .to_owned();


### PR DESCRIPTION
Inserting edges that do not satisfy the foreign key constraint with nodes is now an invalid operation for StarfishQL.

Therefore filtering out invalid edges is now performed in freeport/backend with JavaScript.