### PR TITLE
Update Cargo.toml

### DIFF
--- a/starfish/starfish-core/Cargo.toml
+++ b/starfish/starfish-core/Cargo.toml
@@ -35,7 +35,7 @@ futures-executor = { version = "^0.3" }
 async-trait = { version = "^0.1" }
 serde = { version = "^1" }
 serde_json = { version = "^1" }
-serde_repr = { version = "^0" }
+serde_repr = { version = "^0.1" }
 num_cpus = { version = "^1" }
 
 [features]


### PR DESCRIPTION
## PR Info

## Changes

- [x] 
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.